### PR TITLE
fix(ci): fix name for charmcraft secret

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.4.0
         with:
-          credentials: ${{ secrets.CHARMCRAFT_AUTH }}
+          credentials: ${{ secrets.CHARMCRAFT_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}


### PR DESCRIPTION
This commit fixes the name of the charmcraft secret configured.