### PR TITLE
fix(ci): fix the typo to the secret name

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.4.0
         with:
-          credentials: ${{ secrets.CHARMCRAFT_TOKEN }}
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}


### PR DESCRIPTION
This commit fixes the secret name from CHARMCRAFT_TOKEN to CHARMHUB_TOKEN.