### PR TITLE
fix charm upgrade from the reactive charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,9 +8,6 @@ description: |
 subordinate: false
 tags:
     - misc
-series:
-    - focal
-    - jammy
 provides:
       client:
           interface: nats

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops==2.7.0
+ops==2.8.0
 cryptography==41.0.4
 jinja2==3.1.2
 git+https://github.com/canonical/ops-lib-nrpe.git#egg=ops-lib-nrpe

--- a/src/charm.py
+++ b/src/charm.py
@@ -111,10 +111,7 @@ class NatsCharm(CharmBase):
 
     def _on_config_changed(self, event: ConfigChangedEvent):
         config = dict(self.model.config)
-        if (
-            not (config["tls-cert"] or config["tls-key"] or config["tls-ca-cert"])
-            and self.ca_client.is_ready
-        ):
+        if not (config["tls-cert"] and config["tls-key"]) and self.ca_client.is_ready:
             logger.info("Configuring CA certificates from relation")
             key = self.ca_client.key.private_bytes(
                 encoding=serialization.Encoding.PEM,

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,6 +92,8 @@ class NatsCharm(CharmBase):
         self.framework.observe(self.nrpe_client.on.nrpe_available, self._on_nrpe_ready)
 
     def _on_client_relation_joined(self, event: RelationJoinedEvent):
+        if self.ca_client.is_joined and not self.ca_client.is_ready:
+            event.defer()
         self.nats_client.expose_nats(auth_token=self.state.auth_token)
 
     def _on_install(self, event: InstallEvent):

--- a/tests/integration/relation_tests/application-charm/metadata.yaml
+++ b/tests/integration/relation_tests/application-charm/metadata.yaml
@@ -4,7 +4,6 @@ description: a testing application for nats charm
 summary: A simple application to relate to the nats interface to test the nats charm
 subordinate: false
 series:
-    - focal
     - jammy
 requires:
     client:

--- a/tests/integration/relation_tests/application-charm/src/charm.py
+++ b/tests/integration/relation_tests/application-charm/src/charm.py
@@ -24,7 +24,10 @@ class ApplicationCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     def _on_client_relation_changed(self, event):
-        unit_data = event.relation.data.get(event.unit)
+        # FIXME: sometimes the remote unit i.e event.unit is empty when this
+        # hook is fired so we try to pick the first unit from the relation data
+        remote_unit = event.unit or event.relation.units.pop()
+        unit_data = event.relation.data.get(remote_unit)
         if not unit_data:
             logger.error("data not found in relation")
             self.unit.status = ops.BlockedStatus("waiting for relation data")

--- a/tests/integration/relation_tests/application-charm/src/charm.py
+++ b/tests/integration/relation_tests/application-charm/src/charm.py
@@ -51,6 +51,10 @@ class ApplicationCharm(ops.CharmBase):
         # the connection to each unit individually using their listen addresses
         # and check if each unit has the knowledge of cluster members as well.
         async def _verify_connection(url: str, opts: dict):
+            if url.startswith("tls") and opts.get("tls"):
+                raise Exception(
+                    f"tls connection required for: {url}, but no ceritificate available"
+                )
             client = await nats.connect(url, **opts)
             logger.info(f"connected to {url}")
             if self.config["check_clustering"]:

--- a/tests/integration/relation_tests/test_clustering.py
+++ b/tests/integration/relation_tests/test_clustering.py
@@ -4,12 +4,11 @@ import pytest
 from helpers import (
     APP_NAMES,
     APPLICATION_APP_NAME,
+    CHARM_NAME,
     TEST_APP_CHARM_PATH,
     check_relation_data_existence,
 )
 from pytest_operator.plugin import OpsTest
-
-from tests.integration.relation_tests.helpers import CHARM_NAME
 
 
 @pytest.mark.skip_if_deployed

--- a/tests/integration/relation_tests/test_clustering.py
+++ b/tests/integration/relation_tests/test_clustering.py
@@ -13,6 +13,7 @@ from tests.integration.relation_tests.helpers import CHARM_NAME
 
 
 @pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
 async def test_deploy_cluster(ops_test: OpsTest):
     charms = await ops_test.build_charms(".", TEST_APP_CHARM_PATH)
     async with ops_test.fast_forward():

--- a/tests/integration/relation_tests/test_tls.py
+++ b/tests/integration/relation_tests/test_tls.py
@@ -34,7 +34,7 @@ async def test_deploy_tls(ops_test: OpsTest):
             ),
         )
         await ops_test.model.wait_for_idle(
-            apps=[*APP_NAMES, TLS_CA_CHARM_NAME], status="active", timeout=1000
+            apps=[*APP_NAMES, TLS_CA_CHARM_NAME], status="active", timeout=5000
         )
 
 

--- a/tests/integration/relation_tests/test_tls.py
+++ b/tests/integration/relation_tests/test_tls.py
@@ -1,11 +1,9 @@
 import asyncio
 
 import pytest
-from helpers import APP_NAMES, APPLICATION_APP_NAME, TEST_APP_CHARM_PATH
+from helpers import APP_NAMES, APPLICATION_APP_NAME, CHARM_NAME, TEST_APP_CHARM_PATH
 from nrpe.client import logging
 from pytest_operator.plugin import OpsTest
-
-from tests.integration.relation_tests.helpers import CHARM_NAME
 
 TLS_CA_CHARM_NAME = "easyrsa"
 

--- a/tests/integration/relation_tests/test_tls.py
+++ b/tests/integration/relation_tests/test_tls.py
@@ -11,6 +11,7 @@ TLS_CA_CHARM_NAME = "easyrsa"
 
 
 @pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
 async def test_deploy_tls(ops_test: OpsTest):
     charms = await ops_test.build_charms(".", TEST_APP_CHARM_PATH)
     async with ops_test.fast_forward():

--- a/tests/integration/relation_tests/test_upgrade.py
+++ b/tests/integration/relation_tests/test_upgrade.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import pytest
+from helpers import APP_NAMES, APPLICATION_APP_NAME, TEST_APP_CHARM_PATH
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.relation_tests.helpers import CHARM_NAME
+
+TLS_CA_CHARM_NAME = "easyrsa"
+OLD_CHARM_NAME = "nats-charmers-nats"
+
+
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_old(ops_test: OpsTest):
+    test_app = await ops_test.build_charm(TEST_APP_CHARM_PATH)
+    async with ops_test.fast_forward():
+        await asyncio.gather(
+            ops_test.model.deploy(
+                OLD_CHARM_NAME,
+                application_name=CHARM_NAME,
+                num_units=1,
+                channel="stable",
+                series="jammy",
+            ),
+            ops_test.model.deploy(
+                test_app,
+                application_name=APPLICATION_APP_NAME,
+                num_units=1,
+            ),
+            ops_test.model.deploy(
+                TLS_CA_CHARM_NAME,
+                application_name=TLS_CA_CHARM_NAME,
+                channel="stable",
+                num_units=1,
+            ),
+        )
+        await ops_test.model.relate(f"{TLS_CA_CHARM_NAME}:client", f"{CHARM_NAME}:ca-client")
+        await ops_test.model.relate(f"{APPLICATION_APP_NAME}:client", f"{CHARM_NAME}:client")
+        await ops_test.model.wait_for_idle(
+            apps=[*APP_NAMES, TLS_CA_CHARM_NAME],
+            status="active",
+            timeout=5000,
+            # Do not raise on error as the charms sometime transition from
+            # an `error` state while forming relations
+            raise_on_error=False,
+        )
+
+
+async def test_upgrade_switch(ops_test: OpsTest):
+    charm = await ops_test.build_charm(".")
+    await ops_test.model.applications[CHARM_NAME].refresh(path=charm)
+    await ops_test.model.wait_for_idle(apps=[*APP_NAMES, TLS_CA_CHARM_NAME], status="active")

--- a/tests/integration/relation_tests/test_upgrade.py
+++ b/tests/integration/relation_tests/test_upgrade.py
@@ -1,10 +1,8 @@
 import asyncio
 
 import pytest
-from helpers import APP_NAMES, APPLICATION_APP_NAME, TEST_APP_CHARM_PATH
+from helpers import APP_NAMES, APPLICATION_APP_NAME, CHARM_NAME, TEST_APP_CHARM_PATH
 from pytest_operator.plugin import OpsTest
-
-from tests.integration.relation_tests.helpers import CHARM_NAME
 
 TLS_CA_CHARM_NAME = "easyrsa"
 OLD_CHARM_NAME = "nats-charmers-nats"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -12,8 +12,11 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
+logging.basicConfig(level=logging.DEBUG)
+
 
 @pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
 async def test_smoke(ops_test: OpsTest):
     charm = await ops_test.build_charm(".", verbosity="debug")
     app = await ops_test.model.deploy(charm)

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     # renovate: datasource=pypi
     pytest==7.4.1
     # renovate: datasource=pypi
-    pytest-operator==0.29.0
+    pytest-operator==0.32.0
     nats-py==2.4.0
     tenacity==8.2.3
     -r{toxinidir}/requirements.txt
@@ -86,4 +86,5 @@ commands =
            --tb native \
            --ignore={[vars]tst_path}unit \
            --log-cli-level=INFO \
+           --asyncio-mode=auto \
            {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -76,8 +76,9 @@ deps =
     pytest==7.4.1
     # renovate: datasource=pypi
     pytest-operator==0.32.0
-    nats-py==2.4.0
+    nats-py==2.6.0
     tenacity==8.2.3
+    git+https://github.com/juju/juju-crashdump.git
     -r{toxinidir}/requirements.txt
 commands =
     pip install -q juju=={env:LIBJUJU}


### PR DESCRIPTION
This commit fixes the case for upgrade from the reactive version of this charm to this version (i.e ops). The state from the previous charm used to get lost when doing a `juju refresh --swtich 'nats' --channel 'stable'` in order to replace the old charm with this charm. This resulted in an inconsistent relation data where the newer charm did not know if there was tls relation formed with other charms before hand. Consequently the newer charm used to refresh the nats snap to host the `non-tls` version.