### PR TITLE
Noble support for nats operator charm

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,6 +16,10 @@ on:
         type: string
         description: 'Scope the workflow should run with. Allowed values are: all, build-only'
         default: 'all'
+      cache:
+        description: Whether to use cache for faster builds
+        default: false
+        type: boolean
 
 jobs:
   static-and-unit-tests:
@@ -65,8 +69,11 @@ jobs:
         uses: canonical/setup-lxd@54a5806e490d92e207b57183cf111ed54bbdeff4 # v0.1.2
         with:
           channel: 5.21/stable
-      - name: Install charmcraft
-        run: sudo snap install --classic --channel=latest/stable charmcraft
+      - name: Install charmcraft and charmcraftcache
+        run: |
+          sudo snap install --classic --channel=latest/stable charmcraft
+          sudo apt install -y pipx
+          pipx install charmcraftcache==0.6.3
       - name: Cache Deps
         id: cache-charm-deps
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
@@ -80,9 +87,13 @@ jobs:
         run: |
           for version in $VERSIONS ; do
             platform=ubuntu@${version}:${{ matrix.platform.arch }}
-            charmcraft pack \
-                  --platform="$platform" \
-                  --verbose
+            cmd=charmcraft
+            if '${{ inputs.cache }}' ; then
+              cmd=charmcraftcache
+            fi
+              "$cmd" pack \
+              --platform="$platform" \
+              --verbose
           done
           # Make the created cache dir accessible by user to enable it to be
           # cached later on

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
-  collect-bases:
-    name: Collect bases for charm
+  collect-platforms:
+    name: Collect supported platforms for charm
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -43,20 +43,20 @@ jobs:
         # Reverse lookup for artifact base index to its architecture
         ./scripts/get-runners.py
     outputs:
-      bases: ${{ steps.charm-to-runner.outputs.bases }}
+      platforms: ${{ steps.charm-to-runner.outputs.platforms }}
 
   build:
-    name: 'Build ${{ matrix.arch.name }}-${{ matrix.arch.arch }}'
+    name: 'Build ${{ matrix.platform.charm_name }}-${{ matrix.platform.version }}-${{ matrix.platform.arch }}'
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ fromJSON(needs.collect-bases.outputs.bases) }}
+        platform: ${{ fromJSON(needs.collect-platforms.outputs.platforms) }}
     needs:
-      - collect-bases
+      - collect-platforms
       - static-and-unit-tests
     env:
       PIP_CACHE_DIR: /tmp/cache/pip
-    runs-on: ["self-hosted", "linux", "${{ matrix.arch.arch == 'amd64' && 'X64' || 'ARM64' }}", "jammy", "large"]
+    runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "${{ matrix.platform.version == '22.04' && 'jammy' || 'noble' }}", "large"]
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{ env.PIP_CACHE_DIR }}/**
-          key: charm-deps-${{ matrix.arch.arch }}-${{ hashFiles('**/requirements.txt') }}
+          key: charm-deps-${{ matrix.platform.arch }}-${{ hashFiles('**/requirements.txt') }}
       - name: Build charm
         id: build_charm
         run: |
@@ -78,7 +78,11 @@ jobs:
               sudo chown root ${PIP_CACHE_DIR}
             fi
             sudo pip config set global.cache-dir ${PIP_CACHE_DIR}
-            sudo charmcraft pack --destructive-mode --verbose
+
+            platform=ubuntu@${{ matrix.platform.version }}:${{ matrix.platform.arch }}
+            sudo charmcraft pack --platform="$platform" \
+                    --destructive-mode \
+                    --verbose
             # Make the created cache dir accessible by user to enable it to be
             # cached later on
             sudo chown -R $(whoami) ${PIP_CACHE_DIR}
@@ -86,13 +90,13 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: logs-charmcraft-build-base-${{ matrix.arch.name }}-${{ matrix.arch.base }}
+          name: logs-charmcraft-build-base-${{ matrix.platform.charm_name }}-${{ matrix.platform.version }}-${{ matrix.platform.arch }}
           path: ~/.local/state/charmcraft/log/
           if-no-files-found: error
       - name: Upload charm package
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: ${{ matrix.arch.name }}-charm-${{ matrix.arch.arch }}
+          name: ${{ matrix.platform.charm_name }}-charm-${{ matrix.platform.version }}-${{ matrix.platform.arch }}
           # .empty file required to preserve directory structure
           # See https://github.com/actions/upload-artifact/issues/344#issuecomment-1379232156
           path: |
@@ -104,7 +108,7 @@ jobs:
     if: inputs.scope != 'build-only'
     needs:
       - static-and-unit-tests
-      - collect-bases
+      - collect-platforms
       - build
     strategy:
       fail-fast: false
@@ -113,8 +117,8 @@ jobs:
         juju-version:
           - "3.5"  # renovate: latest juju 3
           - "2.9"  # renovate: latest juju 2
-        arch: ${{ fromJSON(needs.collect-bases.outputs.bases) }}
-    runs-on: ["self-hosted", "linux", "${{ matrix.arch.arch == 'amd64' && 'X64' || 'ARM64' }}", "jammy", "large"]
+        platform: ${{ fromJSON(needs.collect-platforms.outputs.platforms) }}
+    runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "${{ matrix.platform.version == '22.04' && 'jammy' || 'noble' }}", "large"]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -122,7 +126,7 @@ jobs:
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         id: downloaded-charm
         with:
-          name: ${{ matrix.arch.name }}-charm-${{ matrix.arch.arch }}
+          name: ${{ matrix.platform.charm_name }}-charm-${{ matrix.platform.version }}-${{ matrix.platform.arch }}
       - name: Set channel
         run: |
           juju_channel=$(echo "${{ matrix.juju-version }}" | cut -c 1-3)
@@ -135,7 +139,12 @@ jobs:
           juju-channel: "${{ env.JUJU_CHANNEL }}"
       - name: Run integration tests
         run: |
-          if [ "${{ matrix.arch.arch }}" == "arm64" ]; then
+          # Only run integration test on jammy until we have all nats-operator charms supported running on noble and published to the store.
+          if [ "${{ matrix.platform.version }}" == "24.04" ]; then
+            echo "Disable integration test on noble until nats-operator charms supported running on noble and published to the store."
+            exit 0
+          fi
+          if [ "${{ matrix.platform.arch }}" == "arm64" ]; then
             args+="--constraints arch=arm64"
           fi
           ls *.charm | xargs -I {} ./scripts/run-integration-tests --charm=./{} ${args}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -55,37 +55,33 @@ jobs:
       - collect-platforms
       - static-and-unit-tests
     env:
-      PIP_CACHE_DIR: /tmp/cache/pip
-    runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "${{ matrix.platform.version == '22.04' && 'jammy' || 'noble' }}", "large"]
+      CRAFT_SHARED_CACHE: /tmp/charmcraft
+    runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "jammy", "large"]
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup LXD
+        uses: canonical/setup-lxd@54a5806e490d92e207b57183cf111ed54bbdeff4 # v0.1.2
+        with:
+          channel: 5.21/stable
       - name: Install charmcraft
         run: sudo snap install --classic --channel=latest/stable charmcraft
       - name: Cache Deps
         id: cache-charm-deps
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
-          path: ${{ env.PIP_CACHE_DIR }}/**
+          path: ${{ env.CRAFT_SHARED_CACHE }}/**
           key: charm-deps-${{ matrix.platform.arch }}-${{ hashFiles('**/requirements.txt') }}
       - name: Build charm
         id: build_charm
         run: |
-            # Make the restored cache dir accessible by root as we run
-            # charmcraft using sudo in order to use destructive-mode
-            if [ -d ${PIP_CACHE_DIR} ]; then
-              sudo chown root ${PIP_CACHE_DIR}
-            fi
-            sudo pip config set global.cache-dir ${PIP_CACHE_DIR}
-
             platform=ubuntu@${{ matrix.platform.version }}:${{ matrix.platform.arch }}
-            sudo charmcraft pack --platform="$platform" \
-                    --destructive-mode \
+            charmcraft pack --platform="$platform" \
                     --verbose
             # Make the created cache dir accessible by user to enable it to be
             # cached later on
-            sudo chown -R $(whoami) ${PIP_CACHE_DIR}
+            sudo chown -R $(whoami) ${CRAFT_SHARED_CACHE}
       - name: Upload charmcraft logs
         if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -46,7 +46,7 @@ jobs:
       platforms: ${{ steps.charm-to-runner.outputs.platforms }}
 
   build:
-    name: 'Build ${{ matrix.platform.charm_name }}-${{ matrix.platform.version }}-${{ matrix.platform.arch }}'
+    name: 'Build ${{ matrix.platform.charm_name }}-${{ matrix.platform.arch }}'
     strategy:
       fail-fast: false
       matrix:
@@ -75,24 +75,29 @@ jobs:
           key: charm-deps-${{ matrix.platform.arch }}-${{ hashFiles('**/requirements.txt') }}
       - name: Build charm
         id: build_charm
+        env:
+          VERSIONS: ${{ join(matrix.platform.versions, ' ') }}
         run: |
-            platform=ubuntu@${{ matrix.platform.version }}:${{ matrix.platform.arch }}
-            charmcraft pack --platform="$platform" \
-                    --verbose
-            # Make the created cache dir accessible by user to enable it to be
-            # cached later on
-            sudo chown -R $(whoami) ${CRAFT_SHARED_CACHE}
+          for version in $VERSIONS ; do
+            platform=ubuntu@${version}:${{ matrix.platform.arch }}
+            charmcraft pack \
+                  --platform="$platform" \
+                  --verbose
+          done
+          # Make the created cache dir accessible by user to enable it to be
+          # cached later on
+          sudo chown -R "$USER" ${CRAFT_SHARED_CACHE}
       - name: Upload charmcraft logs
         if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: logs-charmcraft-build-base-${{ matrix.platform.charm_name }}-${{ matrix.platform.version }}-${{ matrix.platform.arch }}
+          name: logs-charmcraft-build-base-${{ matrix.platform.charm_name }}-${{ matrix.platform.arch }}
           path: ~/.local/state/charmcraft/log/
           if-no-files-found: error
       - name: Upload charm package
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: ${{ matrix.platform.charm_name }}-charm-${{ matrix.platform.version }}-${{ matrix.platform.arch }}
+          name: ${{ matrix.platform.charm_name }}-charm-${{ matrix.platform.arch }}
           # .empty file required to preserve directory structure
           # See https://github.com/actions/upload-artifact/issues/344#issuecomment-1379232156
           path: |
@@ -114,7 +119,7 @@ jobs:
           - "3.5"  # renovate: latest juju 3
           - "2.9"  # renovate: latest juju 2
         platform: ${{ fromJSON(needs.collect-platforms.outputs.platforms) }}
-    runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "${{ matrix.platform.version == '22.04' && 'jammy' || 'noble' }}", "large"]
+    runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "jammy", "large"]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -122,7 +127,7 @@ jobs:
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         id: downloaded-charm
         with:
-          name: ${{ matrix.platform.charm_name }}-charm-${{ matrix.platform.version }}-${{ matrix.platform.arch }}
+          name: ${{ matrix.platform.charm_name }}-charm-${{ matrix.platform.arch }}
       - name: Set channel
         run: |
           juju_channel=$(echo "${{ matrix.juju-version }}" | cut -c 1-3)
@@ -134,14 +139,19 @@ jobs:
           provider: lxd
           juju-channel: "${{ env.JUJU_CHANNEL }}"
       - name: Run integration tests
+        env:
+          VERSIONS: ${{ join(matrix.platform.versions, ' ') }}
         run: |
           # Only run integration test on jammy until we have all nats-operator charms supported running on noble and published to the store.
-          if [ "${{ matrix.platform.version }}" == "24.04" ]; then
-            echo "Disable integration test on noble until nats-operator charms supported running on noble and published to the store."
-            exit 0
-          fi
-          if [ "${{ matrix.platform.arch }}" == "arm64" ]; then
-            args+="--constraints arch=arm64"
-          fi
-          ls *.charm | xargs -I {} ./scripts/run-integration-tests --charm=./{} ${args}
+          # versions="${{ join(matrix.platform.versions, ' ') }}"
+          for version in $VERSIONS ; do
+            if [ "${version}" == "24.04" ]; then
+              echo "Disable integration test on noble until nats-operator charms supported running on noble and published to the store."
+              exit 0
+            fi
+            if [ "${{ matrix.platform.arch }}" == "arm64" ]; then
+              args+="--constraints arch=arm64"
+            fi
+            ls *22.04*.charm | xargs -I {} ./scripts/run-integration-tests --charm=./{} ${args}
+          done
 

--- a/.github/workflows/promote-charm.yaml
+++ b/.github/workflows/promote-charm.yaml
@@ -37,14 +37,10 @@ jobs:
       run: |
         track=latest
 
-        for series in jammy ; do
+        for series in jammy noble ; do
           ./scripts/promote-charms.sh \
             --from="$track"/${{ inputs.from-risk }} \
             --to="$track"/${{ inputs.to-risk }} \
             --series=${series}
         done
-
-        ./scripts/promote-bundles.sh \
-          --from="$track"/${{ inputs.from-risk }} \
-          --to="$track"/${{ inputs.to-risk }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Fetch charm artifacts
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
       with:
-        pattern: 'nats-operator-charm-a[mr][dm]64'
+        pattern: 'nats-operator-charm-*-a[mr][dm]64'
         path: "${{ github.workspace }}/charms"
         merge-multiple: true
     - name: Upload charms to charmhub
@@ -82,7 +82,20 @@ jobs:
           fi
           base=(${charm[1]//-/ })
           set -e
+          case "${base[1]}" in
+            22.04)
+              series="jammy"
+              ;;
+            24.04)
+              series="noble"
+              ;;
+            *)
+              echo "ERROR: Unsupported Ubuntu series: ${base[1]}"
+              exit 1
+              ;;
+          esac
+
           rev="$(charmcraft status "${charm[0]}" --format=json | jq ".[].mappings[] | select(.base.channel == \"${base[1]}\" and .base.architecture == \"${base[2]}\") | .releases[] | select(.channel == \"$charm_channel\") | .revision")"
-          echo "Published charm: ${charm[0]}, revision: $rev"
+          echo "Published charm: ${charm[0]}, series: ${series}, architecture: ${base[2]}, revision: $rev"
         done
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -36,13 +36,11 @@ resources:
     filename: nats.snap
     description: NATS snap to install
 
-bases:
-- name: "ubuntu"
-  channel: "22.04"
-  architectures: [arm64]
-- name: "ubuntu"
-  channel: "22.04"
-  architectures: [amd64]
+platforms:
+  ubuntu@22.04:amd64:
+  ubuntu@22.04:arm64:
+  ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
 parts:
   charm:
     charm-requirements: ["requirements.txt"]

--- a/scripts/get-runners.py
+++ b/scripts/get-runners.py
@@ -21,26 +21,22 @@ def main() -> int:
     with open("charmcraft.yaml", "r") as f:
         charmcraft_cfg = yaml.safe_load(f)
     data = []
-    for arch in SUPPORTED_ARCHITECTURES:
+    for platform in charmcraft_cfg.get("platforms", {}):
+        distro, arch = platform.split(":")
+        version = distro.split("@")[-1]
+        if arch not in SUPPORTED_ARCHITECTURES:
+            raise ValueError(f"Unsupported architecture: {arch}")
         data.append(
             {
-                "bases": [],
+                "version": version,
                 "arch": arch,
-                "name": charm_name,
+                "charm_name": charm_name,
             }
         )
 
-    for base_idx, base in enumerate(charmcraft_cfg["bases"]):
-        for arch in base["architectures"]:
-            if arch not in SUPPORTED_ARCHITECTURES:
-                raise ValueError(f"Base {base_idx} architecture: {arch} is not supported")
-            for runner in data:
-                if runner["arch"] == arch:
-                    runner["bases"].append(base_idx)
-
-    logging.info(f"bases: {data}")
+    logging.info(f"platforms: {data}")
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-        f.write(f"bases={json.dumps(data)}")
+        f.write(f"platforms={json.dumps(data)}")
     return 0
 
 

--- a/scripts/promote-charms.sh
+++ b/scripts/promote-charms.sh
@@ -49,6 +49,9 @@ case "$series" in
   jammy)
     base=22.04
     ;;
+  noble)
+    base=24.04
+    ;;
   *)
     echo "ERROR: Unsupported series $series"
     exit 1


### PR DESCRIPTION
Charmcraft 3.3.0+ supports building charms with multiple bases.
This change adds support for it. Meanwhile, it tweaks the workflows
to build/publish multi base charms.