### PR TITLE
Enable integration test

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -150,19 +150,9 @@ jobs:
           provider: lxd
           juju-channel: "${{ env.JUJU_CHANNEL }}"
       - name: Run integration tests
-        env:
-          VERSIONS: ${{ join(matrix.platform.versions, ' ') }}
         run: |
-          # Only run integration test on jammy until we have all nats-operator charms supported running on noble and published to the store.
-          # versions="${{ join(matrix.platform.versions, ' ') }}"
-          for version in $VERSIONS ; do
-            if [ "${version}" == "24.04" ]; then
-              echo "Disable integration test on noble until nats-operator charms supported running on noble and published to the store."
-              exit 0
-            fi
-            if [ "${{ matrix.platform.arch }}" == "arm64" ]; then
-              args+="--constraints arch=arm64"
-            fi
-            ls *22.04*.charm | xargs -I {} ./scripts/run-integration-tests --charm=./{} ${args}
-          done
+          if [ "${{ matrix.platform.arch }}" == "arm64" ]; then
+            args+="--constraints arch=arm64"
+          fi
+          ls *.charm | xargs -I {} ./scripts/run-integration-tests --charm=./{} ${args}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,53 @@
 #
 # Copyright 2024 Canonical Ltd.  All rights reserved.
 #
+import zipfile
 from pathlib import Path
 
 import pytest
 import yaml
+
+OLD_CHARM_NAME = "nats-charmers-nats"
+
+
+UBUNTU_SERIES_MAP = {
+    "22.04": "jammy",
+    "24.04": "noble",
+}
+
+
+def extract_series(charm_path):
+    with zipfile.ZipFile(charm_path, "r") as f:
+        metadata_file = next((m for m in f.namelist() if m.endswith("manifest.yaml")), None)
+        if metadata_file:
+            metadata_content = f.read(metadata_file).decode("utf-8")
+            metadata = yaml.safe_load(metadata_content)
+            bases = metadata.get("bases", [])
+            if bases:
+                channel = bases[0].get("channel")
+                if channel in UBUNTU_SERIES_MAP:
+                    return UBUNTU_SERIES_MAP[channel]
+                raise ValueError("Invalid or unsupported Ubuntu series")
+
+    raise ValueError("Failed to extract series from charm metadata")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        f"skip_upgrade_on_noble: Skip upgrade test as {OLD_CHARM_NAME} is not available on Noble.",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    if "skip_upgrade_on_noble" in item.keywords:
+        charm_path = item.config.getoption("--charm")
+        series = extract_series(charm_path)
+        if series == "noble":
+            pytest.skip(
+                f"{OLD_CHARM_NAME} is unavailable on Noble. Skipping the upgrade test on Noble."
+            )
 
 
 def pytest_addoption(parser):

--- a/tests/integration/relation_tests/test_upgrade.py
+++ b/tests/integration/relation_tests/test_upgrade.py
@@ -13,6 +13,7 @@ OLD_CHARM_NAME = "nats-charmers-nats"
 
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
+@pytest.mark.skip_upgrade_on_noble
 async def test_deploy_old(ops_test: OpsTest, constraints, charm_name):
     if constraints:
         await ops_test.model.set_constraints(constraints)
@@ -50,6 +51,7 @@ async def test_deploy_old(ops_test: OpsTest, constraints, charm_name):
         )
 
 
+@pytest.mark.skip_upgrade_on_noble
 async def test_upgrade_switch(
     ops_test: OpsTest,
     charm_path,


### PR DESCRIPTION
## Done

enable the pytest integration tests on noble by default

## QA

[Steps for testing the changes]

## JIRA / Launchpad bug

Fixes AC-3139

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
