### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The Anbox team owns all for now
+*    @canonical/anbox


### PR DESCRIPTION
## Done

Define the team as responsible for all PRs on GitHub. Ensure that the team gets notified of PRs and issues on the nats repository.

This follows what we have in the other repos.

## QA

N/A

## JIRA / Launchpad bug

N/A

## Documentation

N/A
