### PR TITLE
fix(.gh): update artifact pattern to match charm builds correctly

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Fetch charm artifacts
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
       with:
-        pattern: 'nats-operator-charm-*-a[mr][dm]64'
+        pattern: 'nats-operator-charm-a[mr][dm]64'
         path: "${{ github.workspace }}/charms"
         merge-multiple: true
     - name: Upload charms to charmhub


### PR DESCRIPTION
The previous pattern `'nats-operator-charm-*-a[mr][dm]64'` required an
extra hyphen before the architecture name, causing a mismatch when
fetching artifacts.

This change fixed that.

## Done

[Summary of work items]

## QA

This ensures the publish workflow working as intended. 
See https://github.com/canonical/nats-operator/actions/runs/13954048746 for details

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
