### PR TITLE
Correct Ubuntu version extraction in publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -81,8 +81,9 @@ jobs:
               fi
           fi
           base=(${charm[1]//-/ })
+          version="${base[0]#*@}"
           set -e
-          case "${base[1]}" in
+          case "$version" in
             22.04)
               series="jammy"
               ;;
@@ -90,12 +91,12 @@ jobs:
               series="noble"
               ;;
             *)
-              echo "ERROR: Unsupported Ubuntu series: ${base[1]}"
+              echo "ERROR: Unsupported Ubuntu series: ${version}"
               exit 1
               ;;
           esac
 
-          rev="$(charmcraft status "${charm[0]}" --format=json | jq ".[].mappings[] | select(.base.channel == \"${base[1]}\" and .base.architecture == \"${base[2]}\") | .releases[] | select(.channel == \"$charm_channel\") | .revision")"
-          echo "Published charm: ${charm[0]}, series: ${series}, architecture: ${base[2]}, revision: $rev"
+          rev="$(charmcraft status "${charm[0]}" --format=json | jq ".[].mappings[] | select(.base.channel == \"${version}\" and .base.architecture == \"${base[1]}\") | .releases[] | select(.channel == \"$charm_channel\") | .revision")"
+          echo "Published charm: ${charm[0]}, series: ${series}, architecture: ${base[1]}, revision: $rev"
         done
 


### PR DESCRIPTION
The workflow incorrectly extracted the Ubuntu version from the charm 
file name, leading to potential errors in series detection. As a result, it fails
in publishing nats charm to the store.

This change fixed that.

## Done

[Summary of work items]

## QA

[Steps for testing the changes]

## JIRA / Launchpad bug

Fixes https://github.com/canonical/nats-operator/actions/runs/13962747735/job/39087163228

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
