### PR TITLE
fix(gh): don't run pr workflow on pushes

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,9 +8,6 @@ on:
       - ".github/workflows/update-libs.yaml"
       - ".gitignore"
       - ".jujuignore"
-  push:
-    branches:
-      - "renovate/*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Done

This makes the workflow run twice for pull requests for renovate which we don't want.

## QA

Check PR created by renovate after merging this one and check that the pull request workflow is only run once.

## JIRA / Launchpad bug

n/a

## Documentation

n/a
