### PR TITLE
Pin rpds-py to 0.24.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ jinja2==3.1.6
 jsonschema==4.23.0
 pydantic==2.11.4
 packaging==25.0
+rpds-py==0.24.0
 git+https://github.com/canonical/ops-lib-nrpe.git#egg=ops-lib-nrpe


### PR DESCRIPTION
[Summary of work items]

jsonschema v4.24.0 pulls in rpds-py>=0.7.1, but the latest rpds-py
(0.25.1), which was just released on may 21, 2025 requires feature
`edition2024`, which isn't supported by the cargo 1.78.0 or 1.18.0.
Until now, it's unstable and only available in the rust nighlty build.

Hence pinning rpds-py to 0.24.0 ensures compatibility and allows
the charm to build successfully.

## QA

Ensure the nats charm can be built successfully 

## JIRA / Launchpad bug

Fixes https://github.com/canonical/nats-operator/actions/runs/15293761587/job/43018051321

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A: no, it doesnt.