### PR TITLE
Pin GH actions to digests with semver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
         ":semanticCommits",
         ":semanticCommitScope(deps)",
         "docker:pinDigests",
-        "helpers:pinGitHubActionDigests",
+        "helpers:pinGitHubActionDigestsToSemver",
         "regexManagers:dockerfileVersions",
         "group:allNonMajor"
     ],


### PR DESCRIPTION
## Done

Use the same renovate config as the other repos, where GitHub actions are pinned to specific hashes and follow Semver.
This helps us stay consistent across repos, and is also easier to maake sense of when reviewing renovate PRs.

## QA

Check next renovate PRs.

## JIRA / Launchpad bug

N/A

## Documentation

N/A
