### PR TITLE
chore(.gh): correct the workflow name(promote-charms -> promote-charm)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -120,7 +120,7 @@ jobs:
       channel: ${{ needs.publish-to-edge.outputs.test_channel }}
 
   promote-to-beta:
-    uses: ./.github/workflows/promote-charms.yaml
+    uses: ./.github/workflows/promote-charm.yaml
     needs: [run-integration-test]
     with:
       from-risk: edge/${{ needs.publish-to-edge.outputs.branch }}


### PR DESCRIPTION
## Done

chore(.gh): correct the workflow name(promote-charms -> promote-charm)

## QA

[Steps for testing the changes]

## JIRA / Launchpad bug

Fixes https://github.com/canonical/nats-operator/actions/runs/17373196387

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A: no, it doesn't.