### PR TITLE
Promote charms for both amd64 and arm64

### DIFF
--- a/.github/workflows/promote-charm.yaml
+++ b/.github/workflows/promote-charm.yaml
@@ -37,10 +37,13 @@ jobs:
         CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
       run: |
         track="${{ steps.track.outputs.track }}"
-        for series in jammy noble ; do
-          ./scripts/promote-charms.sh \
-            --from="$track"/${{ inputs.from-risk }} \
-            --to="$track"/${{ inputs.to-risk }} \
-            --series=${series}
+        for arch in amd64 arm64; do
+          for series in jammy noble ; do
+            ./scripts/promote-charms.sh \
+              --from="${track}"/${{ inputs.from-risk }} \
+              --to="${track}"/${{ inputs.to-risk }} \
+              --series="${series}" \
+              --arch="${arch}"
+          done
         done
 


### PR DESCRIPTION
## Done

Update the promotion workflow to run `promote-charms.sh` for each
combination of series and architectures. This ensures charms are 
promoted across both supported architectures, not just amd64.

## QA

[Steps for testing the changes]

## JIRA / Launchpad bug

Fixes https://github.com/canonical/anbox-cloud-charms/actions/runs/17750194212/job/50443940452?pr=751

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: no, it doesn't