### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
     env:
       CRAFT_SHARED_CACHE: /tmp/charmcraft
     runs-on: ["self-hosted", "linux", "${{ matrix.platform.arch == 'amd64' && 'X64' || 'ARM64' }}", "jammy", "large"]
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops==3.2.0
-cryptography==45.0.5
+cryptography==46.0.0
 jinja2==3.1.6
 jsonschema==4.25.0
 pydantic==2.11.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ jsonschema==4.25.0
 pydantic==2.11.7
 packaging==25.0
 rpds-py==0.24.0
+pyOpenSSL==25.3.0
 git+https://github.com/canonical/ops-lib-nrpe.git#egg=ops-lib-nrpe

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,6 @@ deps =
     # renovate: datasource=pypi
     coverage[toml]==7.9.2
     # renovate: datasource=pypi
-    pyOpenSSL==25.1.0
-    # renovate: datasource=pypi
     pytest==8.4.2
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
## Done

- chore(deps): update dependency pyOpenSSL to 25.3.0 
- chore(deps): update dependency cryptography to v46

## QA

Ensure unit tests and build succeed for  nats charms

## JIRA / Launchpad bug

Fixes https://github.com/canonical/anbox-cloud-charms/actions/runs/17781777646/job/50541974484?pr=753

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: yes, the dependency update information should be included in the next release.